### PR TITLE
sepolicy: Revert custom sdcardfs policy in favor of AOSP

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -55,10 +55,3 @@
 
 # bash
 /system/xbin/bash                               u:object_r:shell_exec:s0
-
-# emulated storage via sdcardfs
-/mnt/runtime/(default|read|write)/emulated/[0-9](/.*)?  u:object_r:media_rw_data_file:s0
-/storage/emulated/[0-9](/.*)?                           u:object_r:media_rw_data_file:s0
-/mnt/shell/emulated/([1-9])?[0-9](/.*)?                 u:object_r:media_rw_data_file:s0
-/data/media\.tmp(/.*)?                                  u:object_r:media_rw_data_file:s0
-

--- a/sepolicy/genfs_contexts
+++ b/sepolicy/genfs_contexts
@@ -1,4 +1,3 @@
 genfscon fuseblk / u:object_r:sdcard_external:s0
 genfscon exfat / u:object_r:sdcard_external:s0
 genfscon ntfs / u:object_r:sdcard_external:s0
-genfscon sdcardfs / u:object_r:fuse:s0

--- a/sepolicy/mediaserver.te
+++ b/sepolicy/mediaserver.te
@@ -1,7 +1,3 @@
 # Themed resources (i.e. composed icons)
 allow mediaserver theme_data_file:dir r_dir_perms;
 allow mediaserver theme_data_file:file r_file_perms;
-
-# sdcardfs
-allow mediaserver media_rw_data_file:dir { create rw_dir_perms };
-allow mediaserver media_rw_data_file:file create_file_perms;

--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -7,5 +7,3 @@ allow system_server persist_property_file:dir rw_dir_perms;
 allow system_server persist_property_file:file { create_file_perms unlink };
 
 allow system_server storage_stub_file:dir { getattr };
-
-allow system_server media_rw_data_file:dir r_dir_perms;


### PR DESCRIPTION
 * Upstream policy showed up in AOSP this morning. Dropping
   ours in favor of AOSP.

Revert "sepolicy: A few more denials"

This reverts commit 522c421f6623be6437e444454cac58f7bbd5bc32.

Revert "sepolicy: More policy for sdcardfs"

This reverts commit 4a24ffeb6a44b2a044c2c3ce4e5aad8956e7157a.

Revert "sepolicy: Add sdcardfs support"

This reverts commit ba87877dd0b193a29a7b5293e4889c310dcdfc8a.

Change-Id: I4f066b9bd5d8c899137fcaa12999f2547f9e0ec0